### PR TITLE
set field text by label refactored and PAkeys were fixed

### DIFF
--- a/src/test/java/com/bytezone/dm3270/TerminalClientTest.java
+++ b/src/test/java/com/bytezone/dm3270/TerminalClientTest.java
@@ -619,4 +619,14 @@ public class TerminalClientTest {
     awaitKeyboardUnlock();
     assertThat(getScreenText()).isEqualTo(getFileContent("user-menu-screen.txt"));
   }
+  
+  @Test 
+  public void shouldSetTextWhenNoScreenFieldsWhileInputByLabel() throws Exception {
+    setupExtendedFlow(TERMINAL_MODEL_TYPE_TWO, new ScreenDimensions(24, 80), "/sscplu-login.yml");
+    awaitKeyboardUnlock();
+    sendFieldByLabel("APPLICATION NAME", "testapp");
+    awaitKeyboardUnlock();
+    assertThat(getScreenText()).isEqualTo(getFileContent("sscplu-login-middle-screen"));
+  }
+  
 }

--- a/src/test/resources/sscplu-login-middle-screen
+++ b/src/test/resources/sscplu-login-middle-screen
@@ -1,0 +1,24 @@
+                                                                                
+       SYSTEM: TESTAPP  WELCOME TO   DM3270 TESTING APPLICATION                 
+                        TST SERVER 1.0.0 .                                      
+     TERMINAL: 9999                                                             
+         NODE: XXXXXXXX                                                         
+                                                                                
+          DAY: TUESDAY                                                          
+                                                                                
+  SYSTEM DATE: JANUARY 08, 2019                                                 
+  SYSTEM TIME: 01:36 PM                                                         
+                                                                                
+      LOGONID: ===>                                                             
+     PASSWORD: ===>                                                             
+                                                                                
+ NEW PASSWORD: ===>                                                             
+ (ENTER TWICE) ===>                                                             
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+                                                                                


### PR DESCRIPTION
- `setFieldTextByLabel` has been refactored, due to this modifications the protocol is able to handle screen when no fields were found and screen is demanding an input.

- Additionally, program attention keys were not working under sscplu sessions, now they do.