### PR TITLE
tabulated input improved to behave as a tabulator should

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To use the emulator as maven dependency include in `pom.xml`:
   <dependency>
       <groupId>com.github.blazemeter</groupId>
       <artifactId>dm3270</artifactId>
-      <version>0.12.2-lib</version>
+      <version>0.12.3-lib</version>
   </dependency>
   ...
 </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <artifactId>dm3270-lib</artifactId>
   <!-- This version has no relation to the released version since the release version is extracted
   from git tag by Travis -->
-  <version>0.12.3-SNAPSHOT</version>
+  <version>0.12.4-SNAPSHOT</version>
 
   <name>${project.artifactId}</name>
   <description>This is a trimmed down version of https://github.com/dmolony/dm3270 to be used as

--- a/src/test/java/com/bytezone/dm3270/TerminalClientTest.java
+++ b/src/test/java/com/bytezone/dm3270/TerminalClientTest.java
@@ -682,7 +682,20 @@ public class TerminalClientTest {
     assertThat(getScreenText()).isEqualTo(getSccpLuLoginSuccessScreen());
   }
 
-  public void sendFieldByTab(String text, int offset) {
+  public void sendFieldByTab(String text, int offset) throws NoSuchFieldException {
     client.setTabulatedInput(text, offset);
+  }
+
+  @Test
+  public void shouldSetTabulatorInputWhenCursorPosLacksFieldAndOffsetBiggerThanZero()
+      throws Exception {
+    awaitKeyboardUnlock();
+    sendFieldByCoord(1, 27, "testusr");
+    sendEnter();
+    awaitKeyboardUnlock();
+    client.setCursorPosition(50);
+    sendFieldByTab("testpsw", 1);
+    sendEnter();
+    awaitKeyboardUnlock();
   }
 }


### PR DESCRIPTION
Tabulator input has suffered some modifications in order to match behaves with a terminal tabulator.
For instance, when setting a zero offset and the current cursor position lacks field, the operation is canceled.
In another case, if the current cursor position does not contain a field, but we've got an offset bigger than zero, it will lookup for the field to positions above.